### PR TITLE
Add @template variant annotations to the same annotations group

### DIFF
--- a/ShipMonkCodingStandard/ruleset.xml
+++ b/ShipMonkCodingStandard/ruleset.xml
@@ -165,6 +165,10 @@
                 "/>
                 <element value="
                     @template,
+                    @template-covariant,
+                    @template-contravariant,
+                    @template-extends,
+                    @template-implements,
                     @extends,
                     @implements,
                 "/>


### PR DESCRIPTION
## Summary
- Add `@template-covariant`, `@template-contravariant`, `@template-extends`, and `@template-implements` to the same `annotationsGroups` group as `@template`, `@extends`, and `@implements`