### PR TITLE
Use @template* wildcard to avoid reordering template annotations

### DIFF
--- a/ShipMonkCodingStandard/ruleset.xml
+++ b/ShipMonkCodingStandard/ruleset.xml
@@ -164,11 +164,7 @@
                     @return,
                 "/>
                 <element value="
-                    @template,
-                    @template-covariant,
-                    @template-contravariant,
-                    @template-extends,
-                    @template-implements,
+                    @template*,
                     @extends,
                     @implements,
                 "/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,5 +9,7 @@
     <file>ShipMonkCodingStandard/</file>
     <file>tests/</file>
 
+    <exclude-pattern>tests/Data/</exclude-pattern>
+
     <rule ref="ShipMonkCodingStandard"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
 >
     <arg name="basepath" value="."/>
     <arg name="cache" value="cache/phpcs.cache"/>
+    <config name="php_version" value="70400"/>
 
     <file>ShipMonkCodingStandard/</file>
     <file>tests/</file>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,8 @@ parameters:
     paths:
         - ShipMonkCodingStandard
         - tests
+    excludePaths:
+        - tests/Data
     tmpDir: cache/phpstan/
     checkMissingCallableSignature: true
     checkUninitializedProperties: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,11 @@
         failOnWarning="true"
         cacheResultFile="cache/phpunit.result.cache"
 >
+    <testsuites>
+        <testsuite name="tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
     <php>
         <ini name="error_reporting" value="-1"/>
     </php>

--- a/tests/Data/DocCommentSpacing/TemplateAnnotationOrderCorrect.php
+++ b/tests/Data/DocCommentSpacing/TemplateAnnotationOrderCorrect.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\CodingStandard\Data\DocCommentSpacing;
+
+/**
+ * @template-covariant TEntity
+ * @template TEntityId
+ * @extends SomeInterface<TEntity, TEntityId>
+ */
+interface CorrectCovariantBeforeTemplate
+{
+
+}
+
+/**
+ * @template TKey
+ * @template-contravariant TValue
+ * @template-covariant TResult
+ * @implements SomeInterface<TKey, TValue, TResult>
+ */
+interface CorrectMixedTemplateOrder
+{
+
+}
+
+/**
+ * @template T
+ * @template-extends SomeClass<T>
+ * @template-implements SomeInterface<T>
+ * @extends OtherClass<T>
+ * @implements OtherInterface<T>
+ */
+class CorrectTemplateExtendsImplements
+{
+
+}

--- a/tests/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php
+++ b/tests/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\CodingStandard\Data\DocCommentSpacing;
+
+// line 6: IncorrectOrderOfAnnotationsInGroup (@extends before @template)
+/**
+ * @extends SomeInterface<T>
+ * @template T
+ */
+interface ExtendsBeforeTemplate
+{
+
+}
+
+// line 17: IncorrectOrderOfAnnotationsInGroup (@implements before @template)
+/**
+ * @implements SomeInterface<T>
+ * @template T
+ */
+interface ImplementsBeforeTemplate
+{
+
+}
+
+// line 28: IncorrectOrderOfAnnotationsInGroup (@implements before @extends)
+/**
+ * @template T
+ * @implements SomeInterface<T>
+ * @extends OtherInterface<T>
+ */
+interface ImplementsBeforeExtends
+{
+
+}
+
+// lines 37-39: IncorrectAnnotationsGroup (blank line between annotations in same group)
+/**
+ * @template T
+ *
+ * @extends SomeInterface<T>
+ */
+interface BlankLineBetweenAnnotationsInSameGroup
+{
+
+}

--- a/tests/DocCommentSpacingTest.php
+++ b/tests/DocCommentSpacingTest.php
@@ -26,27 +26,20 @@ class DocCommentSpacingTest extends TestCase
         self::assertNoSniffErrors(self::SNIFF_PREFIX, $output);
     }
 
-    public function testExtendsBeforeTemplateIsReported(): void
+    public function testWrongAnnotationOrderIsReported(): void
     {
         $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+
+        // @extends before @template
         self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 7);
-    }
 
-    public function testImplementsBeforeTemplateIsReported(): void
-    {
-        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        // @implements before @template
         self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 17);
-    }
 
-    public function testImplementsBeforeExtendsIsReported(): void
-    {
-        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        // @implements before @extends
         self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 28);
-    }
 
-    public function testBlankLineBetweenAnnotationsInSameGroupIsReported(): void
-    {
-        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        // blank line between annotations in same group
         self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectAnnotationsGroup', $output, 38);
     }
 
@@ -87,9 +80,6 @@ class DocCommentSpacingTest extends TestCase
     /**
      * @param list<string> $phpcsOutput
      */
-    /**
-     * @param list<string> $phpcsOutput
-     */
     private static function assertSniffErrorOnLine(
         string $sniffCode,
         array $phpcsOutput,
@@ -106,6 +96,7 @@ class DocCommentSpacingTest extends TestCase
 
             if (strpos($outputLine, $sniffCode) !== false && $currentLine === $expectedLine) {
                 $found = true;
+                break;
             }
         }
 

--- a/tests/DocCommentSpacingTest.php
+++ b/tests/DocCommentSpacingTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\CodingStandard;
+
+use PHPUnit\Framework\TestCase;
+use function escapeshellarg;
+use function exec;
+use function implode;
+use function strpos;
+use const PHP_EOL;
+
+class DocCommentSpacingTest extends TestCase
+{
+
+    /**
+     * Verify that @template* annotations are not reordered relative to each other.
+     * The order of @template, @template-covariant, and @template-contravariant determines
+     * template parameter position in PHPStan's type system, so reordering changes semantics.
+     */
+    public function testTemplateAnnotationsAreNotReordered(): void
+    {
+        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderCorrect.php');
+        self::assertNoSniffErrors('SlevomatCodingStandard.Commenting.DocCommentSpacing', $output);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function runPhpcs(string $filePath): array
+    {
+        $phpcs = __DIR__ . '/../vendor/bin/phpcs';
+        $output = [];
+        exec($phpcs . ' --standard=ShipMonkCodingStandard -s ' . escapeshellarg($filePath), $output);
+        return $output;
+    }
+
+    /**
+     * @param list<string> $phpcsOutput
+     */
+    private static function assertNoSniffErrors(
+        string $sniffPrefix,
+        array $phpcsOutput,
+    ): void
+    {
+        $relevantErrors = [];
+
+        foreach ($phpcsOutput as $line) {
+            if (strpos($line, $sniffPrefix) !== false) {
+                $relevantErrors[] = $line;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $relevantErrors,
+            'Expected no ' . $sniffPrefix . ' errors, but found:' . PHP_EOL . implode(PHP_EOL, $relevantErrors),
+        );
+    }
+
+}

--- a/tests/DocCommentSpacingTest.php
+++ b/tests/DocCommentSpacingTest.php
@@ -59,7 +59,7 @@ class DocCommentSpacingTest extends TestCase
      */
     private static function assertNoSniffErrors(
         string $sniffPrefix,
-        array $phpcsOutput,
+        array $phpcsOutput
     ): void
     {
         $relevantErrors = [];
@@ -83,7 +83,7 @@ class DocCommentSpacingTest extends TestCase
     private static function assertSniffErrorOnLine(
         string $sniffCode,
         array $phpcsOutput,
-        int $expectedLine,
+        int $expectedLine
     ): void
     {
         $currentLine = 0;

--- a/tests/DocCommentSpacingTest.php
+++ b/tests/DocCommentSpacingTest.php
@@ -6,11 +6,14 @@ use PHPUnit\Framework\TestCase;
 use function escapeshellarg;
 use function exec;
 use function implode;
+use function preg_match;
 use function strpos;
 use const PHP_EOL;
 
 class DocCommentSpacingTest extends TestCase
 {
+
+    private const SNIFF_PREFIX = 'SlevomatCodingStandard.Commenting.DocCommentSpacing';
 
     /**
      * Verify that @template* annotations are not reordered relative to each other.
@@ -20,7 +23,31 @@ class DocCommentSpacingTest extends TestCase
     public function testTemplateAnnotationsAreNotReordered(): void
     {
         $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderCorrect.php');
-        self::assertNoSniffErrors('SlevomatCodingStandard.Commenting.DocCommentSpacing', $output);
+        self::assertNoSniffErrors(self::SNIFF_PREFIX, $output);
+    }
+
+    public function testExtendsBeforeTemplateIsReported(): void
+    {
+        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 7);
+    }
+
+    public function testImplementsBeforeTemplateIsReported(): void
+    {
+        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 17);
+    }
+
+    public function testImplementsBeforeExtendsIsReported(): void
+    {
+        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectOrderOfAnnotationsInGroup', $output, 28);
+    }
+
+    public function testBlankLineBetweenAnnotationsInSameGroupIsReported(): void
+    {
+        $output = self::runPhpcs(__DIR__ . '/Data/DocCommentSpacing/TemplateAnnotationOrderWrong.php');
+        self::assertSniffErrorOnLine(self::SNIFF_PREFIX . '.IncorrectAnnotationsGroup', $output, 38);
     }
 
     /**
@@ -30,7 +57,7 @@ class DocCommentSpacingTest extends TestCase
     {
         $phpcs = __DIR__ . '/../vendor/bin/phpcs';
         $output = [];
-        exec($phpcs . ' --standard=ShipMonkCodingStandard -s ' . escapeshellarg($filePath), $output);
+        exec($phpcs . ' --standard=ShipMonkCodingStandard --no-colors -s ' . escapeshellarg($filePath), $output);
         return $output;
     }
 
@@ -54,6 +81,38 @@ class DocCommentSpacingTest extends TestCase
             [],
             $relevantErrors,
             'Expected no ' . $sniffPrefix . ' errors, but found:' . PHP_EOL . implode(PHP_EOL, $relevantErrors),
+        );
+    }
+
+    /**
+     * @param list<string> $phpcsOutput
+     */
+    /**
+     * @param list<string> $phpcsOutput
+     */
+    private static function assertSniffErrorOnLine(
+        string $sniffCode,
+        array $phpcsOutput,
+        int $expectedLine,
+    ): void
+    {
+        $currentLine = 0;
+        $found = false;
+
+        foreach ($phpcsOutput as $outputLine) {
+            if (preg_match('~^\s*(\d+)\s*\|~', $outputLine, $matches) === 1) {
+                $currentLine = (int) $matches[1];
+            }
+
+            if (strpos($outputLine, $sniffCode) !== false && $currentLine === $expectedLine) {
+                $found = true;
+            }
+        }
+
+        self::assertTrue(
+            $found,
+            'Expected ' . $sniffCode . ' error on line ' . $expectedLine
+            . ', but not found in output:' . PHP_EOL . implode(PHP_EOL, $phpcsOutput),
         );
     }
 


### PR DESCRIPTION
## Summary
- Use `@template*` wildcard in `annotationsGroups` so that `@template`, `@template-covariant`, `@template-contravariant`, `@template-extends`, and `@template-implements` all share the same priority and preserve source order
- The previous explicit listing enforced `@template` before `@template-covariant`, which could silently break PHPStan's positional type parameter mapping
- Add PHPUnit test verifying DocCommentSpacing accepts valid template annotation orderings
- Configure `phpunit.xml.dist` with a testsuite so tests are discovered
- Exclude `tests/Data/` from phpcs and phpstan

Fixes #14