### PR TITLE
Upgrade shipmonk/dead-code-detector to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^9.6",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "shipmonk/dead-code-detector": "^0.12",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1",
         "shipmonk/phpstan-rules": "^4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "shipmonk/dead-code-detector": "^0.12",
+        "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1",
         "shipmonk/phpstan-rules": "^4.1"
     },


### PR DESCRIPTION
## Summary
- Upgrade `shipmonk/dead-code-detector` from `^0.12` to `^1.0`

Co-Authored-By: Claude Code