### PR TITLE
Require PHP 8.1+, modernize toolchain

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,8 +11,30 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
+        steps:
+            -
+                name: Checkout code
+                uses: actions/checkout@v6
+            -
+                name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.5
+            -
+                name: Install dependencies
+                run: composer install --no-progress --prefer-dist --no-interaction
+
+            -
+                name: Run checks
+                run: composer check
+
+    tests:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
             matrix:
-                php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+                php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
+                dependency-version: [prefer-lowest, prefer-stable]
         steps:
             -
                 name: Checkout code
@@ -23,9 +45,8 @@ jobs:
                 with:
                     php-version: ${{ matrix.php-version }}
             -
-                name: Install dependencies
-                run: composer install --no-progress --prefer-dist --no-interaction
-
+                name: Update dependencies
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             -
-                name: Run checks
-                run: composer check
+                name: Run tests
+                run: composer check:tests

--- a/ShipMonkCodingStandard/Sniffs/Arrays/DoubleArrowSpacingSniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Arrays/DoubleArrowSpacingSniff.php
@@ -6,7 +6,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use function in_array;
 use function ltrim;
-use function strpos;
+use function str_contains;
 use const T_DOUBLE_ARROW;
 use const T_FN_ARROW;
 use const T_MATCH_ARROW;
@@ -22,7 +22,7 @@ final class DoubleArrowSpacingSniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -52,7 +52,7 @@ final class DoubleArrowSpacingSniff implements Sniff
         if (!$beforeValid) {
             if ($before['code'] !== T_WHITESPACE) {
                 $phpcsFile->fixer->addContentBefore($pointer, ' ');
-            } elseif (strpos($before['content'], "\n") === false) {
+            } elseif (!str_contains($before['content'], "\n")) {
                 $phpcsFile->fixer->replaceToken($pointer - 1, ' ');
             }
         }
@@ -60,7 +60,7 @@ final class DoubleArrowSpacingSniff implements Sniff
         if (!$afterValid) {
             if ($after['code'] !== T_WHITESPACE) {
                 $phpcsFile->fixer->addContent($pointer, ' ');
-            } elseif (strpos($after['content'], "\n") === false) {
+            } elseif (!str_contains($after['content'], "\n")) {
                 $phpcsFile->fixer->replaceToken($pointer + 1, ' ');
             } else {
                 // whitespace runs into a newline: drop the trailing spaces, keep the line break

--- a/ShipMonkCodingStandard/Sniffs/ControlStructures/EmptyConditionBodySniff.php
+++ b/ShipMonkCodingStandard/Sniffs/ControlStructures/EmptyConditionBodySniff.php
@@ -32,7 +32,7 @@ final class EmptyConditionBodySniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/ShipMonkCodingStandard/Sniffs/Whitespaces/CatchSpacingSniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Whitespaces/CatchSpacingSniff.php
@@ -39,7 +39,7 @@ final class CatchSpacingSniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $catchPointer
+        $catchPointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();
@@ -196,7 +196,7 @@ final class CatchSpacingSniff implements Sniff
     private function addOrReplaceWhitespaceToken(
         File $phpcsFile,
         int $pointer,
-        string $whitespaceContent
+        string $whitespaceContent,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/ShipMonkCodingStandard/Sniffs/Whitespaces/DisallowOneLineDocCommentSniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Whitespaces/DisallowOneLineDocCommentSniff.php
@@ -29,7 +29,7 @@ final class DisallowOneLineDocCommentSniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/ShipMonkCodingStandard/Sniffs/Whitespaces/MultilineConditionSpacingSniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Whitespaces/MultilineConditionSpacingSniff.php
@@ -22,7 +22,7 @@ final class MultilineConditionSpacingSniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/ShipMonkCodingStandard/Sniffs/Whitespaces/MultilineTernarySniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Whitespaces/MultilineTernarySniff.php
@@ -18,7 +18,7 @@ final class MultilineTernarySniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/ShipMonkCodingStandard/Sniffs/Whitespaces/OpenParenthesisSpacingSniff.php
+++ b/ShipMonkCodingStandard/Sniffs/Whitespaces/OpenParenthesisSpacingSniff.php
@@ -20,7 +20,7 @@ final class OpenParenthesisSpacingSniff implements Sniff
      */
     public function process(
         File $phpcsFile,
-        $pointer
+        $pointer,
     ): void
     {
         $tokens = $phpcsFile->getTokens();

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "phpcodesniffer-standard",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-tokenizer": "*",
         "slevomat/coding-standard": "^8.28.0",
         "squizlabs/php_codesniffer": "^4.0.1"
@@ -16,7 +16,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5.62",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "shipmonk/dead-code-detector": "^0.12",
         "shipmonk/name-collision-detector": "^2.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
 >
     <arg name="basepath" value="."/>
     <arg name="cache" value="cache/phpcs.cache"/>
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
 
     <file>ShipMonkCodingStandard/</file>
     <file>tests/</file>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,8 @@ includes:
 
 parameters:
     phpVersion:
-        min: 70400
-        max: 80499
+        min: 80100
+        max: 80599
     internalErrorsCountLimit: 1
     featureToggles:
         internalTag: false # sniffs consume SlevomatCodingStandard @internal helpers, the intended way to build sniffs

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,11 +5,10 @@
         bootstrap="vendor/autoload.php"
         beStrictAboutOutputDuringTests="true"
         beStrictAboutChangesToGlobalState="true"
-        beStrictAboutCoversAnnotation="true"
-        beStrictAboutTodoAnnotatedTests="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        cacheResultFile="cache/phpunit.result.cache"
+        beStrictAboutCoverageMetadata="true"
+        failOnAllIssues="true"
+        displayDetailsOnAllIssues="true"
+        cacheDirectory="cache/phpunit"
 >
     <testsuites>
         <testsuite name="tests">

--- a/tests/DocCommentSpacingTest.php
+++ b/tests/DocCommentSpacingTest.php
@@ -7,7 +7,7 @@ use function escapeshellarg;
 use function exec;
 use function implode;
 use function preg_match;
-use function strpos;
+use function str_contains;
 use const PHP_EOL;
 
 class DocCommentSpacingTest extends TestCase
@@ -59,13 +59,13 @@ class DocCommentSpacingTest extends TestCase
      */
     private static function assertNoSniffErrors(
         string $sniffPrefix,
-        array $phpcsOutput
+        array $phpcsOutput,
     ): void
     {
         $relevantErrors = [];
 
         foreach ($phpcsOutput as $line) {
-            if (strpos($line, $sniffPrefix) !== false) {
+            if (str_contains($line, $sniffPrefix)) {
                 $relevantErrors[] = $line;
             }
         }
@@ -83,7 +83,7 @@ class DocCommentSpacingTest extends TestCase
     private static function assertSniffErrorOnLine(
         string $sniffCode,
         array $phpcsOutput,
-        int $expectedLine
+        int $expectedLine,
     ): void
     {
         $currentLine = 0;
@@ -94,7 +94,7 @@ class DocCommentSpacingTest extends TestCase
                 $currentLine = (int) $matches[1];
             }
 
-            if (strpos($outputLine, $sniffCode) !== false && $currentLine === $expectedLine) {
+            if (str_contains($outputLine, $sniffCode) && $currentLine === $expectedLine) {
                 $found = true;
                 break;
             }

--- a/tests/SniffTestCase.php
+++ b/tests/SniffTestCase.php
@@ -53,7 +53,7 @@ abstract class SniffTestCase extends TestCase
 
     protected static function assertErrorCount(
         File $file,
-        int $expectedErrorCount
+        int $expectedErrorCount,
     ): void
     {
         self::assertSame($expectedErrorCount, $file->getErrorCount());


### PR DESCRIPTION
Raises the PHP floor to `^8.1` and modernizes the project, following the recently-migrated ShipMonk OSS packages (`name-collision-detector`, `composer-dependency-analyser`).

## Changes

**Version floor & dependencies**
- `composer.json`: `php` `^7.4 || ^8.0` → `^8.1`; `phpunit/phpunit` `^9.6` → `^10.5.62`
- `phpstan.neon.dist`: `phpVersion.min` `70400` → `80100`, `max` `80499` → `80599`
- `phpcs.xml.dist`: `php_version` `70400` → `80100`

**PHPUnit 10 config migration** (`phpunit.xml.dist`)
- `beStrictAboutCoversAnnotation` → `beStrictAboutCoverageMetadata`
- `beStrictAboutTodoAnnotatedTests` / `failOnRisky` / `failOnWarning` → `failOnAllIssues` + `displayDetailsOnAllIssues`
- `cacheResultFile` → `cacheDirectory`

**CI** (`.github/workflows/checks.yml`)
- Drop PHP 7.4 / 8.0
- Split into a `checks` job (full `composer check` on PHP 8.5) and a `tests` matrix over PHP 8.1–8.5 × `prefer-lowest`/`prefer-stable` (Linux-only — `DocCommentSpacingTest` execs `vendor/bin/phpcs` directly, which won't work on Windows)

**Source modernization**
- `strpos(…) === false` → `!str_contains(…)` in `DoubleArrowSpacingSniff` and `DocCommentSpacingTest`
- Trailing commas added to multi-line declarations — the `php_version` bump activates slevomat's `RequireTrailingCommaInDeclaration` (a PHP 8.0+ feature previously suppressed); auto-fixed across 9 files

The sniffs were already modern (strict_types, typed signatures, `final`, generics) and are stateless, so there were no properties/constructors to promote. `process(File, $pointer)` keeps `$pointer` untyped because the `Sniff` interface declares it untyped.

## Verification
Full `composer check` passes (cs, phpstan level max, 22 tests, normalize/validate, dependency analyser, collision detector) on both `prefer-stable` (PHPUnit 10.5.63) and `prefer-lowest` (PHPUnit 10.5.62, slevomat 8.28.0).

> [!NOTE]
> Backward-incompatible (raised PHP floor) — should be released as `0.3.0`.

Co-Authored-By: Claude Code